### PR TITLE
Update opening url to eco url

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -226,8 +226,6 @@ function normalizeGame(game) {
       if (ecoMatch && ecoMatch[1]) eco = ecoMatch[1];
       var openingUrlMatch = pgn.match(/\n\[OpeningUrl\s+"([^"]+)"\]/);
       if (openingUrlMatch && openingUrlMatch[1]) openingUrl = openingUrlMatch[1];
-      // Some PGNs may not have OpeningUrl; chess.com often has a URL in the JSON opening_url
-      if (!openingUrl && game.opening_url) openingUrl = game.opening_url;
       // Extract movetext: content after the last closing bracket line of headers
       var splitIndex = pgn.lastIndexOf(']\n');
       if (splitIndex !== -1) {
@@ -240,6 +238,14 @@ function normalizeGame(game) {
     } catch (e) {
       // ignore PGN parse issues
     }
+  }
+
+  // Prefer ECO-based URL for Opening URL when ECO is available
+  if (eco) {
+    openingUrl = 'https://www.365chess.com/eco/' + encodeURIComponent(eco);
+  } else if (!openingUrl && game.opening_url) {
+    // Fallback to any opening URL provided by the source if ECO is missing
+    openingUrl = game.opening_url;
   }
 
   return {


### PR DESCRIPTION
Update opening URL logic to prioritize ECO-based links when an ECO code is available.

---
<a href="https://cursor.com/background-agent?bcId=bc-39edb8d1-42d9-4fa5-83eb-1ac21b3797e0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-39edb8d1-42d9-4fa5-83eb-1ac21b3797e0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

