### PR TITLE
Fix unexpected token in code.gs

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -886,6 +886,7 @@ function backfillCallbackFields(limit) {
   setCol(colMyMembershipCode, myMembershipCodeVals);
   setCol(colMyMembershipLevel, myMembershipLevelVals);
 }
+/**
  * Convenience: backfill both ECO/Opening and Moves/Clocks.
  * @param {number=} limit Optional max rows for each pass
  */


### PR DESCRIPTION
Add missing JSDoc opener to fix `SyntaxError: Unexpected token '*'` caused by an unterminated comment.

---
<a href="https://cursor.com/background-agent?bcId=bc-5bf66c1e-2cfc-4bc2-a7e6-6d1ebb31999d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5bf66c1e-2cfc-4bc2-a7e6-6d1ebb31999d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

