### PR TITLE
Debug san moves and clock headers

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -352,6 +352,12 @@ function normalizeGame(game) {
       if (ecoMatch && ecoMatch[1]) eco = ecoMatch[1];
       var ecoUrlMatch = pgn.match(/^\[(?:ECOUrl|OpeningUrl)\s+"([^"]+)"\]/m);
       if (ecoUrlMatch && ecoUrlMatch[1]) openingUrl = ecoUrlMatch[1];
+      // Also derive SAN moves and Clocks from the PGN movetext for normal flow
+      var sanClockParsed = parsePgnToSanAndClocks(pgn);
+      if (sanClockParsed) {
+        movesSan = sanClockParsed.movesSan || movesSan;
+        clocksStr = sanClockParsed.clocks || clocksStr;
+      }
     } catch (e) {
       // ignore PGN parse issues
     }


### PR DESCRIPTION
Integrate parsing for `Moves (SAN)` and `Clocks` into `normalizeGame` to make them part of the normal data flow.

---
<a href="https://cursor.com/background-agent?bcId=bc-723a4ba1-0418-4f09-83db-c7485047a3c1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-723a4ba1-0418-4f09-83db-c7485047a3c1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

