### PR TITLE
Fix duplicate variable declaration

### DIFF
--- a/gs_opening_from_pgn.gs
+++ b/gs_opening_from_pgn.gs
@@ -3,7 +3,6 @@
 // plus WhiteAccuracy, BlackAccuracy, Result, and extended metrics computed from [%eval]s
 // in a Google Sheet. This relies solely on PGN tags: [Opening "..."] and [ECO "..."]
 
-const SHEET_NAME = 'Games';
 const SCRIPT_PROP_MY_USERNAME_KEY = 'MY_USERNAME';
 
 // Column indices (1-based)


### PR DESCRIPTION
Remove duplicate `SHEET_NAME` constant from `gs_opening_from_pgn.gs` to resolve 'Identifier already declared' error.

---
<a href="https://cursor.com/background-agent?bcId=bc-1e198a8d-44db-4a1c-97ff-743675c3a3b5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1e198a8d-44db-4a1c-97ff-743675c3a3b5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

