### PR TITLE
Format end time to epoch

### DIFF
--- a/fetchConfigured.gs
+++ b/fetchConfigured.gs
@@ -188,6 +188,11 @@ function recalcDerivedV2_(headersSheet, gamesSheet, selectedHeaders) {
   var idxTimeControl = selectedHeaders.findIndex(function(h) { return h.source === 'json' && h.field === 'time_control'; });
   var idxPgn = selectedHeaders.findIndex(function(h) { return h.source === 'json' && h.field === 'pgn'; });
   var idxMoves = selectedHeaders.findIndex(function(h) { return h.source === 'pgn_moves'; });
+  // Additional JSON fields needed for derived computations during recalc
+  var idxEndTime = selectedHeaders.findIndex(function(h) { return h.source === 'json' && h.field === 'end_time'; });
+  var idxRules = selectedHeaders.findIndex(function(h) { return h.source === 'json' && h.field === 'rules'; });
+  var idxTimeClass = selectedHeaders.findIndex(function(h) { return h.source === 'json' && h.field === 'time_class'; });
+  var idxFen = selectedHeaders.findIndex(function(h) { return h.source === 'json' && h.field === 'fen'; });
 
   var values = gamesSheet.getRange(2, 1, lastRow - 1, lastCol).getValues();
   var derivedReg = getDerivedRegistry_();
@@ -197,6 +202,10 @@ function recalcDerivedV2_(headersSheet, gamesSheet, selectedHeaders) {
     // Minimal inputs for compute()
     var game = {};
     if (idxTimeControl !== -1) game.time_control = row[idxTimeControl];
+    if (idxEndTime !== -1) game.end_time = row[idxEndTime];
+    if (idxRules !== -1) game.rules = row[idxRules];
+    if (idxTimeClass !== -1) game.time_class = row[idxTimeClass];
+    if (idxFen !== -1) game.fen = row[idxFen];
     var pgnText = idxPgn !== -1 ? String(row[idxPgn] || '') : '';
     var pgnTags = parsePgnTags_(pgnText);
     var pgnMoves = idxMoves !== -1 ? String(row[idxMoves] || '') : '';


### PR DESCRIPTION
Pass additional JSON fields to derived computations during recalculation to ensure correct population of related derived columns.

The `recalcDerivedV2_` function was not passing all necessary source JSON fields (like `end_time`, `rules`, `time_class`, `fen`) from the existing sheet rows to the derived field computation logic. This resulted in derived columns such as `End Time (Local)`, `Format`, and other clock/board-related fields appearing blank or incorrect after a recalculation, even if their source data was present in the sheet. This change ensures these fields are properly re-evaluated.

---
<a href="https://cursor.com/background-agent?bcId=bc-9a7725e1-ad59-4b2d-91b1-12dff0549564">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9a7725e1-ad59-4b2d-91b1-12dff0549564">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

